### PR TITLE
added setIsInitialShootsLoad(false) in the finally block of the useEf…

### DIFF
--- a/src/components/Shoots/Shoots.jsx
+++ b/src/components/Shoots/Shoots.jsx
@@ -227,6 +227,8 @@ const Shoots = () => {
           setTimeout(() => {
           setIsLoading(false); 
           setShouldUpdateAllShoots(false);
+          // here
+          setIsInitialShootsLoad(false);
           }, minLoadingInterval);
         }
       }

--- a/src/pages/ShootDetails/ShootDetails.jsx
+++ b/src/pages/ShootDetails/ShootDetails.jsx
@@ -28,8 +28,6 @@ const ShootDetails = () => {
   // state for when to render placeholders
   const [ componentIsLoaded, setComponentIsLoaded ] = useState(false);
 
-  // const placeHolderArray = Array.from({ length: 10 });
-
   const handlePhotosLoaded = () => {
     setTimeout(() => {
       setComponentIsLoaded(true);


### PR DESCRIPTION
…ect for fetchAll shoots to test fix for placeholders still showing on navigating from one shootsDetails page to another